### PR TITLE
Support for KUP

### DIFF
--- a/kbin-mod-options.js
+++ b/kbin-mod-options.js
@@ -64,22 +64,21 @@ const styleSheet = document.createElement('style');
 styleSheet.innerText = kmoStyles;
 document.head.appendChild(styleSheet);
 
-window.addEventListener("load", function () {
-    if (document.querySelector('.settings-list')) {
-        const settingsList = document.querySelector('.settings-list');
-        console.log('settingsList');
-    } else if (document.querySelector('.settings-panel')) {
-        const settingsList = document.querySelector('.settings-panel');
-        console.log('settingsPanel');
-    } else {
-        console.log('no panel');
-        throw new Error("kbin-mod-options - Settings pane doesn't exist, did another mod override it?");
-    }
-});
+let settingsList;
 
 function kmoAddHeader(title, info = {}) {
     if (typeof title === 'undefined') {
         throw new Error('kmoAddHeader - title is undefined')
+    }
+    if (document.querySelector('.settings-list')) {
+        settingsList = document.querySelector('.settings-list');
+        console.log('settingsList');
+    } else if (document.querySelector('.settings-panel')) {
+        settingsList = document.querySelector('.settings-panel');
+        console.log('settingsPanel');
+    } else {
+        console.log('no panel');
+        throw new Error("kbin-mod-options - Settings pane doesn't exist, did another mod override it?");
     }
     const headerText = document.createElement('strong');
     headerText.textContent = title;

--- a/kbin-mod-options.js
+++ b/kbin-mod-options.js
@@ -64,13 +64,18 @@ const styleSheet = document.createElement('style');
 styleSheet.innerText = kmoStyles;
 document.head.appendChild(styleSheet);
 
-if (document.querySelector('.settings-list')) {
-    const settingsList = document.querySelector('.settings-list');
-} else if (document.querySelector('.settings-panel')) {
-    const settingsList = document.querySelector('.settings-panel');
-} else {
-    throw new Error("kbin-mod-options - Settings pane doesn't exist, did another mod override it?");
-}
+window.addEventListener("load", function () {
+    if (document.querySelector('.settings-list')) {
+        const settingsList = document.querySelector('.settings-list');
+        console.log('settingsList');
+    } else if (document.querySelector('.settings-panel')) {
+        const settingsList = document.querySelector('.settings-panel');
+        console.log('settingsPanel');
+    } else {
+        throw new Error("kbin-mod-options - Settings pane doesn't exist, did another mod override it?");
+        console.log('no panel');
+    }
+});
 
 function kmoAddHeader(title, info = {}) {
     if (typeof title === 'undefined') {

--- a/kbin-mod-options.js
+++ b/kbin-mod-options.js
@@ -64,17 +64,10 @@ const styleSheet = document.createElement('style');
 styleSheet.innerText = kmoStyles;
 document.head.appendChild(styleSheet);
 
-let settingsList = [];
-if (document.querySelector('.settings-list')) {
-    settingsList.push(document.querySelector('.settings-list'));
-}
-if (document.querySelector('.settings-panel')) {
-    settingsList.push(document.querySelector('.settings-panel'));
-}
 const ourSection = document.createElement('div');
 ourSection.className = 'kmo-settings-list';
 document.querySelector('#settings.section').appendChild(ourSection);
-settingsList.push(ourSection);
+const settingsList = ourSection;
 
 function kmoAddHeader(title, info = {}) {
     if (typeof title === 'undefined') {
@@ -115,12 +108,12 @@ function kmoAddHeader(title, info = {}) {
     headerText.appendChild(show_icon);
     const childDiv = document.createElement('div');
     childDiv.className = 'collapsed';
-    settingsList.forEach(panel => {
-        panel.appendChild(headerText);
-        panel.appendChild(childDiv);
-    });
-    //settingsList.appendChild(headerText);
-    //settingsList.appendChild(childDiv);
+    //settingsList.forEach(panel => {
+    //    panel.appendChild(headerText);
+    //    panel.appendChild(childDiv);
+    //});
+    settingsList.appendChild(headerText);
+    settingsList.appendChild(childDiv);
     show_icon.addEventListener("click", () => {
         kmoToggleSettings(show_icon, childDiv);
     });
@@ -196,10 +189,10 @@ function kmoAddToggle(settingDiv, settingName, currentValue, description = '') {
     toggleDiv.appendChild(toggleLabel);
     thisSettingDiv.appendChild(toggleDiv);
     settingDiv.appendChild(thisSettingDiv);
-    settingsList.forEach(panel => {
-        //settingsList.appendChild(settingDiv);
-        panel.appendChild(settingDiv);
-    });
+    settingsList.appendChild(settingDiv);
+    //settingsList.forEach(panel => {
+    //    panel.appendChild(settingDiv);
+    //});
     return toggleInput;
 }
 
@@ -237,10 +230,10 @@ function kmoAddDropDown(settingDiv, settingName, options, currentValue, descript
     thisSettingDiv.appendChild(settingSpan);
     thisSettingDiv.appendChild(dropDown);
     settingDiv.appendChild(thisSettingDiv);
-    //settingsList.appendChild(settingDiv);
-    settingsList.forEach(panel => {
-        panel.appendChild(settingDiv);
-    });
+    settingsList.appendChild(settingDiv);
+    //settingsList.forEach(panel => {
+    //    panel.appendChild(settingDiv);
+    //});
     return dropDown;
 }
 
@@ -265,10 +258,10 @@ function kmoAddButton(settingDiv, settingName, buttonLabel, description = '') {
     thisSettingDiv.appendChild(settingSpan);
     thisSettingDiv.appendChild(button);
     settingDiv.appendChild(thisSettingDiv);
-    //settingsList.appendChild(settingDiv);
-    settingsList.forEach(panel => {
-        panel.appendChild(settingDiv);
-    });
+    settingsList.appendChild(settingDiv);
+    //settingsList.forEach(panel => {
+    //    panel.appendChild(settingDiv);
+    //});
     return button;
 }
 
@@ -302,9 +295,9 @@ function kmoAddColorDropper(settingDiv, settingName, currentColor, description =
     thisSettingDiv.appendChild(settingSpan);
     thisSettingDiv.appendChild(colorDropper);
     settingDiv.appendChild(thisSettingDiv);
-    //settingsList.appendChild(settingDiv);
-    settingsList.forEach(panel => {
-        panel.appendChild(settingDiv);
-    });
+    settingsList.appendChild(settingDiv);
+    //settingsList.forEach(panel => {
+    //    panel.appendChild(settingDiv);
+    //});
     return colorDropper;
 }

--- a/kbin-mod-options.js
+++ b/kbin-mod-options.js
@@ -70,16 +70,18 @@ function kmoAddHeader(title, info = {}) {
     if (typeof title === 'undefined') {
         throw new Error('kmoAddHeader - title is undefined')
     }
-    if (document.querySelector('.settings-list')) {
-        settingsList = document.querySelector('.settings-list');
-        console.log('settingsList');
-    } else if (document.querySelector('.settings-panel')) {
-        settingsList = document.querySelector('.settings-panel');
-        console.log('settingsPanel');
-    } else {
-        console.log('no panel');
-        throw new Error("kbin-mod-options - Settings pane doesn't exist, did another mod override it?");
-    }
+    window.addEventListener("load", function () {
+        if (document.querySelector('.settings-list')) {
+            settingsList = document.querySelector('.settings-list');
+            console.log('settingsList');
+        } else if (document.querySelector('.settings-panel')) {
+            settingsList = document.querySelector('.settings-panel');
+            console.log('settingsPanel');
+        } else {
+            console.log('no panel');
+            throw new Error("kbin-mod-options - Settings pane doesn't exist, did another mod override it?");
+        }
+    });
     const headerText = document.createElement('strong');
     headerText.textContent = title;
     if (Object.keys(info).length > 0) {

--- a/kbin-mod-options.js
+++ b/kbin-mod-options.js
@@ -64,24 +64,18 @@ const styleSheet = document.createElement('style');
 styleSheet.innerText = kmoStyles;
 document.head.appendChild(styleSheet);
 
-let settingsList;
+let settingsList = [];
+if (document.querySelector('.settings-list')) {
+    settingsList.push(document.querySelector('.settings-list'));
+}
+if (document.querySelector('.settings-panel')) {
+    settingsList.push(document.querySelector('.settings-panel'));
+}
 
 function kmoAddHeader(title, info = {}) {
     if (typeof title === 'undefined') {
         throw new Error('kmoAddHeader - title is undefined')
     }
-    window.addEventListener("load", function () {
-        if (document.querySelector('.settings-list')) {
-            settingsList = document.querySelector('.settings-list');
-            console.log('settingsList');
-        } else if (document.querySelector('.settings-panel')) {
-            settingsList = document.querySelector('.settings-panel');
-            console.log('settingsPanel');
-        } else {
-            console.log('no panel');
-            throw new Error("kbin-mod-options - Settings pane doesn't exist, did another mod override it?");
-        }
-    });
     const headerText = document.createElement('strong');
     headerText.textContent = title;
     if (Object.keys(info).length > 0) {
@@ -115,10 +109,14 @@ function kmoAddHeader(title, info = {}) {
     show_icon.setAttribute('aria-hidden', 'true');
     show_icon.style = 'float:right; text-align: center; margin-top: 0.2rem; margin-right: 10px; cursor: pointer; color: var(--kbin-meta-text-color);';
     headerText.appendChild(show_icon);
-    settingsList.appendChild(headerText);
     const childDiv = document.createElement('div');
     childDiv.className = 'collapsed';
-    settingsList.appendChild(childDiv);
+    settingsList.forEach(panel => {
+        panel.appendChild(headerText);
+        panel.appendChild(childDiv);
+    });
+    //settingsList.appendChild(headerText);
+    //settingsList.appendChild(childDiv);
     show_icon.addEventListener("click", () => {
         kmoToggleSettings(show_icon, childDiv);
     });
@@ -194,7 +192,10 @@ function kmoAddToggle(settingDiv, settingName, currentValue, description = '') {
     toggleDiv.appendChild(toggleLabel);
     thisSettingDiv.appendChild(toggleDiv);
     settingDiv.appendChild(thisSettingDiv);
-    settingsList.appendChild(settingDiv);
+    settingsList.forEach(panel => {
+        //settingsList.appendChild(settingDiv);
+        panel.appendChild(settingDiv);
+    });
     return toggleInput;
 }
 
@@ -232,7 +233,10 @@ function kmoAddDropDown(settingDiv, settingName, options, currentValue, descript
     thisSettingDiv.appendChild(settingSpan);
     thisSettingDiv.appendChild(dropDown);
     settingDiv.appendChild(thisSettingDiv);
-    settingsList.appendChild(settingDiv);
+    //settingsList.appendChild(settingDiv);
+    settingsList.forEach(panel => {
+        panel.appendChild(settingDiv);
+    });
     return dropDown;
 }
 
@@ -257,7 +261,10 @@ function kmoAddButton(settingDiv, settingName, buttonLabel, description = '') {
     thisSettingDiv.appendChild(settingSpan);
     thisSettingDiv.appendChild(button);
     settingDiv.appendChild(thisSettingDiv);
-    settingsList.appendChild(settingDiv);
+    //settingsList.appendChild(settingDiv);
+    settingsList.forEach(panel => {
+        panel.appendChild(settingDiv);
+    });
     return button;
 }
 
@@ -291,6 +298,9 @@ function kmoAddColorDropper(settingDiv, settingName, currentColor, description =
     thisSettingDiv.appendChild(settingSpan);
     thisSettingDiv.appendChild(colorDropper);
     settingDiv.appendChild(thisSettingDiv);
-    settingsList.appendChild(settingDiv);
+    //settingsList.appendChild(settingDiv);
+    settingsList.forEach(panel => {
+        panel.appendChild(settingDiv);
+    });
     return colorDropper;
 }

--- a/kbin-mod-options.js
+++ b/kbin-mod-options.js
@@ -64,7 +64,13 @@ const styleSheet = document.createElement('style');
 styleSheet.innerText = kmoStyles;
 document.head.appendChild(styleSheet);
 
-const settingsList = document.querySelector(".settings-list");
+if (document.querySelector('.settings-list')) {
+    const settingsList = document.querySelector('.settings-list');
+} else if (document.querySelector('.settings-panel')) {
+    const settingsList = document.querySelector('.settings-panel');
+} else {
+    throw new Error("kbin-mod-options - Settings pane doesn't exist, did another mod override it?");
+}
 
 function kmoAddHeader(title, info = {}) {
     if (typeof title === 'undefined') {

--- a/kbin-mod-options.js
+++ b/kbin-mod-options.js
@@ -72,7 +72,7 @@ if (document.querySelector('.settings-panel')) {
     settingsList.push(document.querySelector('.settings-panel'));
 }
 const ourSection = document.createElement('div');
-ourSection.className = 'settings-list kmo-settings-list';
+ourSection.className = 'kmo-settings-list';
 document.querySelector('#settings.section').appendChild(ourSection);
 settingsList.push(ourSection);
 

--- a/kbin-mod-options.js
+++ b/kbin-mod-options.js
@@ -71,6 +71,10 @@ if (document.querySelector('.settings-list')) {
 if (document.querySelector('.settings-panel')) {
     settingsList.push(document.querySelector('.settings-panel'));
 }
+const ourSection = document.createElement('div');
+ourSection.className = 'settings-list kmo-settings-list';
+document.querySelector('#settings.section').appendChild(ourSection);
+settingsList.push(ourSection);
 
 function kmoAddHeader(title, info = {}) {
     if (typeof title === 'undefined') {

--- a/kbin-mod-options.js
+++ b/kbin-mod-options.js
@@ -1,6 +1,6 @@
 /*
     Name:           kbin-mod-options
-    Version:        0.2.1
+    Version:        0.2.2
     Description:    Attempt at standardizing mod options.
     Author:         0rito
     License:        MIT
@@ -108,10 +108,6 @@ function kmoAddHeader(title, info = {}) {
     headerText.appendChild(show_icon);
     const childDiv = document.createElement('div');
     childDiv.className = 'collapsed';
-    //settingsList.forEach(panel => {
-    //    panel.appendChild(headerText);
-    //    panel.appendChild(childDiv);
-    //});
     settingsList.appendChild(headerText);
     settingsList.appendChild(childDiv);
     show_icon.addEventListener("click", () => {
@@ -190,9 +186,6 @@ function kmoAddToggle(settingDiv, settingName, currentValue, description = '') {
     thisSettingDiv.appendChild(toggleDiv);
     settingDiv.appendChild(thisSettingDiv);
     settingsList.appendChild(settingDiv);
-    //settingsList.forEach(panel => {
-    //    panel.appendChild(settingDiv);
-    //});
     return toggleInput;
 }
 
@@ -231,9 +224,6 @@ function kmoAddDropDown(settingDiv, settingName, options, currentValue, descript
     thisSettingDiv.appendChild(dropDown);
     settingDiv.appendChild(thisSettingDiv);
     settingsList.appendChild(settingDiv);
-    //settingsList.forEach(panel => {
-    //    panel.appendChild(settingDiv);
-    //});
     return dropDown;
 }
 
@@ -259,9 +249,6 @@ function kmoAddButton(settingDiv, settingName, buttonLabel, description = '') {
     thisSettingDiv.appendChild(button);
     settingDiv.appendChild(thisSettingDiv);
     settingsList.appendChild(settingDiv);
-    //settingsList.forEach(panel => {
-    //    panel.appendChild(settingDiv);
-    //});
     return button;
 }
 
@@ -296,8 +283,5 @@ function kmoAddColorDropper(settingDiv, settingName, currentColor, description =
     thisSettingDiv.appendChild(colorDropper);
     settingDiv.appendChild(thisSettingDiv);
     settingsList.appendChild(settingDiv);
-    //settingsList.forEach(panel => {
-    //    panel.appendChild(settingDiv);
-    //});
     return colorDropper;
 }

--- a/kbin-mod-options.js
+++ b/kbin-mod-options.js
@@ -72,8 +72,8 @@ window.addEventListener("load", function () {
         const settingsList = document.querySelector('.settings-panel');
         console.log('settingsPanel');
     } else {
-        throw new Error("kbin-mod-options - Settings pane doesn't exist, did another mod override it?");
         console.log('no panel');
+        throw new Error("kbin-mod-options - Settings pane doesn't exist, did another mod override it?");
     }
 });
 


### PR DESCRIPTION
[KBIN Usability Pack (KUP)](https://kbin.social/m/kbinStyles/t/105421/Kbin-Usability-Pack-0-2-1-Now-with-settings) decided to hide instead of updating **.settings-list**. Scripts that are slower, or that check for the DOM to be completely loaded, are subsequently still added to the hidden div. KUP proceeds to create an entirely new structure for their settings module.

To combat KUP's solution, we create a new div outside of the **.settings-list** and just append it to the parent node. The unfortunate side-effect is that there is some spacing issues with KUP's **.settings-panel** whereas things look good without it.